### PR TITLE
fix: update repo links to use bluetooth-devices

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: ["bdraco"]
+github: ["bluetooth-devices"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,55 +4,55 @@
 
 ### Feature
 
-- Add support for propcache v1.0.0+ (#26) ([`f5ac45b`](https://github.com/bdraco/cached-ipaddress/commit/f5ac45bb3c82c38f989494a26b7a773b807c16a2))
+- Add support for propcache v1.0.0+ (#26) ([`f5ac45b`](https://github.com/bluetooth-devices/cached-ipaddress/commit/f5ac45bb3c82c38f989494a26b7a773b807c16a2))
 
 ## v0.7.0 (2024-10-03)
 
 ### Feature
 
-- Switch from stdlib cached_property to propcache cached_property (#25) ([`217d978`](https://github.com/bdraco/cached-ipaddress/commit/217d978f812ebdcfd0a964ff432be4d075deaaf6))
+- Switch from stdlib cached_property to propcache cached_property (#25) ([`217d978`](https://github.com/bluetooth-devices/cached-ipaddress/commit/217d978f812ebdcfd0a964ff432be4d075deaaf6))
 
 ## v0.6.0 (2024-09-23)
 
 ### Feature
 
-- Add cache for compressed (#22) ([`4afea62`](https://github.com/bdraco/cached-ipaddress/commit/4afea62ac571fb79859cbe174dccf250d704fc04))
+- Add cache for compressed (#22) ([`4afea62`](https://github.com/bluetooth-devices/cached-ipaddress/commit/4afea62ac571fb79859cbe174dccf250d704fc04))
 
 ## v0.5.0 (2024-08-26)
 
 ### Feature
 
-- Add python version classifiers (#17) ([`c87a639`](https://github.com/bdraco/cached-ipaddress/commit/c87a639f7d5d7f14ab62a8c7f072bd48440acf27))
+- Add python version classifiers (#17) ([`c87a639`](https://github.com/bluetooth-devices/cached-ipaddress/commit/c87a639f7d5d7f14ab62a8c7f072bd48440acf27))
 
 ## v0.4.0 (2024-08-26)
 
 ### Feature
 
-- Python 3.13 support (#16) ([`75a01d4`](https://github.com/bdraco/cached-ipaddress/commit/75a01d4c5b6e3ee336a3f0e101a5df71510ffb9c))
-- Cache hash as well (#15) ([`282a8ad`](https://github.com/bdraco/cached-ipaddress/commit/282a8ad722d8ee09cc3961f85f989e90a93093ee))
+- Python 3.13 support (#16) ([`75a01d4`](https://github.com/bluetooth-devices/cached-ipaddress/commit/75a01d4c5b6e3ee336a3f0e101a5df71510ffb9c))
+- Cache hash as well (#15) ([`282a8ad`](https://github.com/bluetooth-devices/cached-ipaddress/commit/282a8ad722d8ee09cc3961f85f989e90a93093ee))
 
 ## v0.3.0 (2023-12-17)
 
 ### Feature
 
-- Add reverse_pointer to the cache (#4) ([`98f7ae3`](https://github.com/bdraco/cached-ipaddress/commit/98f7ae3d1e5b3c03f34392093257594915e55d2a))
+- Add reverse_pointer to the cache (#4) ([`98f7ae3`](https://github.com/bluetooth-devices/cached-ipaddress/commit/98f7ae3d1e5b3c03f34392093257594915e55d2a))
 
 ## v0.2.0 (2023-12-16)
 
 ### Feature
 
-- Add is_multicast to the list of cached properties (#3) ([`b5f4941`](https://github.com/bdraco/cached-ipaddress/commit/b5f4941b83dc983bab88bf04a0bcf8a5bc7c60af))
+- Add is_multicast to the list of cached properties (#3) ([`b5f4941`](https://github.com/bluetooth-devices/cached-ipaddress/commit/b5f4941b83dc983bab88bf04a0bcf8a5bc7c60af))
 
 ## v0.1.0 (2023-12-16)
 
 ### Feature
 
-- First version (#2) ([`44bf9b7`](https://github.com/bdraco/cached-ipaddress/commit/44bf9b78f2740f5114bf89a664f5bb42c20c8502))
+- First version (#2) ([`44bf9b7`](https://github.com/bluetooth-devices/cached-ipaddress/commit/44bf9b78f2740f5114bf89a664f5bb42c20c8502))
 
 ## v0.0.1 (2023-12-16)
 
 ### Fix
 
-- Reserve name on pypi (#1) ([`c979f69`](https://github.com/bdraco/cached-ipaddress/commit/c979f69f82763d4231ea9662d320ef552f35c601))
+- Reserve name on pypi (#1) ([`c979f69`](https://github.com/bluetooth-devices/cached-ipaddress/commit/c979f69f82763d4231ea9662d320ef552f35c601))
 
 ## v0.0.0 (2023-12-16)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,4 +114,4 @@ $ pytest tests
 
 The deployment should be automated and can be triggered from the Semantic Release workflow in GitHub. The next version will be based on [the commit logs](https://python-semantic-release.readthedocs.io/en/latest/commit-log-parsing.html#commit-log-parsing). This is done by [python-semantic-release](https://python-semantic-release.readthedocs.io/en/latest/index.html) via a GitHub action.
 
-[gh-issues]: https://github.com/bdraco/cached-ipaddress/issues
+[gh-issues]: https://github.com/bluetooth-devices/cached-ipaddress/issues

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # cached-ipaddress
 
 <p align="center">
-  <a href="https://github.com/bdraco/cached-ipaddress/actions/workflows/ci.yml?query=branch%3Amain">
-    <img src="https://img.shields.io/github/actions/workflow/status/bdraco/cached-ipaddress/ci.yml?branch=main&label=CI&logo=github&style=flat-square" alt="CI Status" >
+  <a href="https://github.com/bluetooth-devices/cached-ipaddress/actions/workflows/ci.yml?query=branch%3Amain">
+    <img src="https://img.shields.io/github/actions/workflow/status/bluetooth-devices/cached-ipaddress/ci.yml?branch=main&label=CI&logo=github&style=flat-square" alt="CI Status" >
   </a>
-  <a href="https://codecov.io/gh/bdraco/cached-ipaddress">
-    <img src="https://img.shields.io/codecov/c/github/bdraco/cached-ipaddress.svg?logo=codecov&logoColor=fff&style=flat-square" alt="Test coverage percentage">
+  <a href="https://codecov.io/gh/bluetooth-devices/cached-ipaddress">
+    <img src="https://img.shields.io/codecov/c/github/bluetooth-devices/cached-ipaddress.svg?logo=codecov&logoColor=fff&style=flat-square" alt="Test coverage percentage">
   </a>
 </p>
 <p align="center">
@@ -29,7 +29,7 @@
 
 ---
 
-**Source Code**: <a href="https://github.com/bdraco/cached-ipaddress" target="_blank">https://github.com/bdraco/cached-ipaddress </a>
+**Source Code**: <a href="https://github.com/bluetooth-devices/cached-ipaddress" target="_blank">https://github.com/bluetooth-devices/cached-ipaddress </a>
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Cache construction of ipaddress objects"
 authors = ["J. Nick Koston <nick@koston.org>"]
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/bdraco/cached-ipaddress"
+repository = "https://github.com/bluetooth-devices/cached-ipaddress"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
@@ -24,8 +24,8 @@ packages = [
 ]
 
 [tool.poetry.urls]
-"Bug Tracker" = "https://github.com/bdraco/cached-ipaddress/issues"
-"Changelog" = "https://github.com/bdraco/cached-ipaddress/blob/main/CHANGELOG.md"
+"Bug Tracker" = "https://github.com/bluetooth-devices/cached-ipaddress/issues"
+"Changelog" = "https://github.com/bluetooth-devices/cached-ipaddress/blob/main/CHANGELOG.md"
 
 [tool.poetry.build]
 generate-setup-file = true


### PR DESCRIPTION
I have been transferring some of the projects that are under my person GitHub to OHF repos since it was hard for other contributors to help out with projects that were hosted on my personal GitHub. Bluetooth-devices has a lot of people I trust so I picked that org even though the fit is a bit strange.  We could later transfer it to home-assistant-libs if desired.